### PR TITLE
Fix getTotalIterationCount() returns getLoopCount()

### DIFF
--- a/webp_decoder/src/main/java/com/bumptech/glide/integration/webp/decoder/WebpDecoder.java
+++ b/webp_decoder/src/main/java/com/bumptech/glide/integration/webp/decoder/WebpDecoder.java
@@ -169,7 +169,7 @@ public class WebpDecoder implements GifDecoder {
         if (mWebPImage.getLoopCount() == 0) {
             return TOTAL_ITERATION_COUNT_FOREVER;
         }
-        return mWebPImage.getFrameCount() + 1;
+        return mWebPImage.getLoopCount();
     }
 
     @Override


### PR DESCRIPTION
It will fix #55 WebpDrawable.setLoopCount(LOOP_INTRINSIC) uses frameCount instead loopCount. 