### PR TITLE
Avoid IllegalArgumentException in WebpFrameLoader

### DIFF
--- a/webp_decoder/src/main/java/com/bumptech/glide/integration/webp/decoder/WebpFrameLoader.java
+++ b/webp_decoder/src/main/java/com/bumptech/glide/integration/webp/decoder/WebpFrameLoader.java
@@ -338,7 +338,7 @@ public class WebpFrameLoader {
 
         public void onResourceReady(Bitmap resource, Transition<? super Bitmap> transition) {
             this.resource = resource;
-            Message msg = handler.obtainMessage(1, this);
+            Message msg = handler.obtainMessage(FrameLoaderCallback.MSG_DELAY, this);
             handler.sendMessageAtTime(msg, targetTime);
         }
 

--- a/webp_decoder/src/main/java/com/bumptech/glide/integration/webp/decoder/WebpFrameLoader.java
+++ b/webp_decoder/src/main/java/com/bumptech/glide/integration/webp/decoder/WebpFrameLoader.java
@@ -276,7 +276,11 @@ public class WebpFrameLoader {
         // already incremented the frame pointer and can't decode the same frame again. Instead we'll
         // just hang on to this next frame until start() or clear() are called.
         if (!isRunning) {
-            pendingTarget = delayTarget;
+            if (startFromFirstFrame) {
+                handler.obtainMessage(FrameLoaderCallback.MSG_CLEAR, delayTarget).sendToTarget();
+            } else {
+                pendingTarget = delayTarget;
+            }
             return;
         }
 


### PR DESCRIPTION
## Description

Avoid IllegalArgumentException in WebpFrameLoader.

This PR is the GlideWebpDecoder version of bumptech/glide#4193.

## Motivation and Context

I encountered IllegalArgumentException, which is  thrown when the target is invisible and startFromFirstFrame is called  and the target subsequently becomes visible.

repo steps:
1. target.setVisible(false, ...)
2. drawable.startFromFirstFrame()
3. (after a while) target.setVisible(true, ...)